### PR TITLE
Auto-reload open files on disk change; simplify commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ This behaviour is controlled by three settings (Settings → Settings Editor →
 - `autoReloadIntervalMs` (default `1500`) — how often, in milliseconds, open files are checked for on-disk changes.
 - `watchedFileExtensions` (default `[".pdf"]`) — the file extensions to watch. Include the leading dot (e.g. `".pdf"`); matching is case-insensitive. Add more (e.g. `".png"`, `".svg"`) to auto-reload other viewers too.
 
+  > ⚠️ Only add extensions for view-only or generated files. Reloading reverts the open document from disk, so any **unsaved edits** to a watched file would be discarded. This is why the default is `.pdf` (a generated, non-edited output).
+
 ## Command
 
 The extension provides one command:

--- a/README.md
+++ b/README.md
@@ -3,22 +3,33 @@
 [![Github Actions Status](https://github.com/imcovangent/jupyterlab_run_and_reload.git/workflows/Build/badge.svg)](https://github.com/imcovangent/jupyterlab_run_and_reload.git/actions/workflows/build.yml)
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/imcovangent/jupyterlab_run_and_reload.git/main?urlpath=lab)
 
-A JupyterLab extension to run all notebook cells and reload static content (e.g. PDF).
+A JupyterLab extension that runs all notebook cells and automatically reloads open PDF viewers whenever their file changes on disk.
 
-This extension is motivated by the use of [pylatex](https://github.com/JelteF/PyLaTeX) in a notebook on Jupyter Lab. When you run a notebook that creates a PDF file, you normally have to manually reload the file if it is already open. With this extension you can simply run your notebook and the PDF file gets reloaded automatically. Like this:
+This extension is motivated by the use of [pylatex](https://github.com/JelteF/PyLaTeX) in a notebook on Jupyter Lab. When you run a notebook that creates a PDF file, you normally have to manually reload the file if it is already open. With this extension the open PDF gets reloaded automatically. Like this:
 
 ![Demo run and reload GIF](https://github.com/imcovangent/jupyterlab_run_and_reload/blob/main/examples/demo_jupyterlab_run_and_reload.gif?raw=true)
 
-The extension provides two commands
+## Automatic PDF reload
 
-- "Run all cells and reload PDFs".
-- "Restart kernel, run all cells and reload PDFs."
+Any open PDF is reloaded automatically whenever its file changes on disk — regardless of what triggered the change: the command below, a headless notebook run (e.g. via the Jupyter MCP or a coding agent), a terminal, a cron job, etc. A PDF that changes is also brought to the front, so a PDF open in a background tab is reloaded and activated.
 
-This commands are available in a notebook in multiple places:
+This behaviour is controlled by two settings (Settings → Settings Editor → *jupyterlab_run_and_reload*):
 
-- Under the run menu
-- Under the keyboard shortcut ctrl + shift + D and ctrl + alt + shift + D respectively
-- In the command palette (ctrl + shift + C)
+- `autoReloadEnabled` (default `true`) — enable or disable the automatic reload.
+- `autoReloadIntervalMs` (default `1500`) — how often, in milliseconds, open PDFs are checked for on-disk changes.
+
+## Command
+
+The extension provides one command:
+
+- **"Run all cells and reload PDFs"** — runs every cell of the active notebook, keeping your current selection and scroll position. Open PDFs are then reloaded automatically as described above.
+
+The command is available in a notebook in multiple places:
+
+- In the notebook toolbar
+- Under the Run menu
+- Under the keyboard shortcut `Ctrl + Shift + D`
+- In the command palette (`Ctrl + Shift + C`)
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -11,12 +11,13 @@ This extension is motivated by the use of [pylatex](https://github.com/JelteF/Py
 
 ## Automatic PDF reload
 
-Any open PDF is reloaded automatically whenever its file changes on disk — regardless of what triggered the change: the command below, a headless notebook run (e.g. via the Jupyter MCP or a coding agent), a terminal, a cron job, etc. A PDF that changes is also brought to the front, so a PDF open in a background tab is reloaded and activated.
+Any open file with a watched extension (PDFs by default) is reloaded automatically whenever its file changes on disk — regardless of what triggered the change: the command below, a headless notebook run (e.g. via the Jupyter MCP or a coding agent), a terminal, a cron job, etc. A file that changes is also brought to the front, so one open in a background tab is reloaded and activated.
 
-This behaviour is controlled by two settings (Settings → Settings Editor → *jupyterlab_run_and_reload*):
+This behaviour is controlled by three settings (Settings → Settings Editor → *jupyterlab_run_and_reload*):
 
 - `autoReloadEnabled` (default `true`) — enable or disable the automatic reload.
-- `autoReloadIntervalMs` (default `1500`) — how often, in milliseconds, open PDFs are checked for on-disk changes.
+- `autoReloadIntervalMs` (default `1500`) — how often, in milliseconds, open files are checked for on-disk changes.
+- `watchedFileExtensions` (default `[".pdf"]`) — the file extensions to watch. Include the leading dot (e.g. `".pdf"`); matching is case-insensitive. Add more (e.g. `".png"`, `".svg"`) to auto-reload other viewers too.
 
 ## Command
 

--- a/README.md
+++ b/README.md
@@ -3,17 +3,17 @@
 [![Github Actions Status](https://github.com/imcovangent/jupyterlab_run_and_reload.git/workflows/Build/badge.svg)](https://github.com/imcovangent/jupyterlab_run_and_reload.git/actions/workflows/build.yml)
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/imcovangent/jupyterlab_run_and_reload.git/main?urlpath=lab)
 
-A JupyterLab extension that runs all notebook cells and automatically reloads open PDF viewers whenever their file changes on disk.
+A JupyterLab extension that runs all notebook cells and automatically reloads open file viewers whenever their file changes on disk (`.pdf` by default; configurable).
 
 This extension is motivated by the use of [pylatex](https://github.com/JelteF/PyLaTeX) in a notebook on Jupyter Lab. When you run a notebook that creates a PDF file, you normally have to manually reload the file if it is already open. With this extension the open PDF gets reloaded automatically. Like this:
 
 ![Demo run and reload GIF](https://github.com/imcovangent/jupyterlab_run_and_reload/blob/main/examples/demo_jupyterlab_run_and_reload.gif?raw=true)
 
-## Automatic PDF reload
+## Automatic file reload
 
-Any open file with a watched extension (PDFs by default) is reloaded automatically whenever its file changes on disk — regardless of what triggered the change: the command below, a headless notebook run (e.g. via the Jupyter MCP or a coding agent), a terminal, a cron job, etc. A file that changes is also brought to the front, so one open in a background tab is reloaded and activated.
+Any open file with a watched extension (`.pdf` by default) is reloaded automatically whenever its file changes on disk — regardless of what triggered the change: the command below, a headless notebook run (e.g. via the Jupyter MCP or a coding agent), a terminal, a cron job, etc. A file that changes is also brought to the front, so one open in a background tab is reloaded and activated.
 
-This behaviour is controlled by three settings (Settings → Settings Editor → *jupyterlab_run_and_reload*):
+This behaviour is controlled by three settings (Settings → Settings Editor → _jupyterlab_run_and_reload_):
 
 - `autoReloadEnabled` (default `true`) — enable or disable the automatic reload.
 - `autoReloadIntervalMs` (default `1500`) — how often, in milliseconds, open files are checked for on-disk changes.
@@ -25,7 +25,7 @@ This behaviour is controlled by three settings (Settings → Settings Editor →
 
 The extension provides one command:
 
-- **"Run all cells and reload PDFs"** — runs every cell of the active notebook, keeping your current selection and scroll position. Open PDFs are then reloaded automatically as described above.
+- **"Run All Cells and Reload Files"** — runs every cell of the active notebook, keeping your current selection and scroll position. Open files are then reloaded automatically as described above.
 
 The command is available in a notebook in multiple places:
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "jupyterlab_run_and_reload",
     "version": "4.1.0",
-    "description": "A JupyterLab extension to run all notebook cells and reload static content (e.g. PDF).",
+    "description": "A JupyterLab extension that runs all notebook cells and automatically reloads open files (e.g. PDFs) when they change on disk.",
     "keywords": [
         "jupyter",
         "jupyterlab",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "jupyterlab_run_and_reload",
-    "version": "4.0.0",
+    "version": "4.1.0",
     "description": "A JupyterLab extension to run all notebook cells and reload static content (e.g. PDF).",
     "keywords": [
         "jupyter",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "dependencies": {
         "@jupyterlab/application": "^4.3.5",
         "@jupyterlab/docmanager": "^4.3.5",
+        "@jupyterlab/docregistry": "^4.3.5",
         "@jupyterlab/launcher": "^4.3.5",
         "@jupyterlab/notebook": "^4.3.5",
         "@jupyterlab/settingregistry": "^4.3.5"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,6 @@
-{% set name = "jupyterlab_run_and_reload" %}
-{% set version = "4.1.0" %}
+{% set pkg = load_file_data("../package.json") %}
+{% set name = pkg.get("name") %}
+{% set version = pkg.get("version") %}
 {% set python_min = "3.9" %}
 
 package:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,6 +21,7 @@ requirements:
     - hatch-nodejs-version >=0.3.2
     - hatchling >=1.5.0
     - jupyterlab =4
+    - nodejs >=18
     - pip
     - python {{ python_min }}
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,0 +1,48 @@
+{% set name = "jupyterlab_run_and_reload" %}
+{% set version = "4.1.0" %}
+{% set python_min = "3.9" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  path: ../
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+  number: 0
+
+requirements:
+  host:
+    - hatch-jupyter-builder >=0.5
+    - hatch-nodejs-version >=0.3.2
+    - hatchling >=1.5.0
+    - jupyterlab =4
+    - pip
+    - python {{ python_min }}
+  run:
+    - python >={{ python_min }},<4.0
+  run_constrained:
+    - jupyterlab >=4,<5
+
+test:
+  requires:
+    - jupyterlab =4
+    - pip
+    - python {{ python_min }}
+  commands:
+    - pip check
+    - jupyter labextension list 2>&1 | grep -ie "jupyterlab_run_and_reload.*OK"
+
+about:
+  home: https://github.com/imcovangent/jupyterlab_run_and_reload
+  summary: 'JupyterLab extension to run all notebook cells and reload external widgets (e.g. PDF documents)'
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - imcovangent

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,7 +40,7 @@ test:
 
 about:
   home: https://github.com/imcovangent/jupyterlab_run_and_reload
-  summary: 'JupyterLab extension to run all notebook cells and reload external widgets (e.g. PDF documents)'
+  summary: 'JupyterLab extension that runs all notebook cells and reloads open files (e.g. PDFs) when they change on disk'
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -2,7 +2,21 @@
   "title": "jupyterlab_run_and_reload",
   "description": "jupyterlab_run_and_reload settings.",
   "type": "object",
-  "properties": {},
+  "properties": {
+    "autoReloadEnabled": {
+      "type": "boolean",
+      "title": "Auto-reload open PDFs on disk change",
+      "description": "When enabled, any open PDF viewer is automatically reloaded whenever its file changes on disk, regardless of what triggered the change (this command, an MCP/coding agent, a terminal, etc.).",
+      "default": true
+    },
+    "autoReloadIntervalMs": {
+      "type": "number",
+      "title": "Auto-reload poll interval (ms)",
+      "description": "How often to check open PDFs for on-disk changes, in milliseconds.",
+      "minimum": 250,
+      "default": 1500
+    }
+  },
   "additionalProperties": false,
   "jupyter.lab.shortcuts": [
     {

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -19,7 +19,7 @@
     "watchedFileExtensions": {
       "type": "array",
       "title": "Watched file extensions",
-      "description": "File extensions whose open viewers are automatically reloaded when the file changes on disk. Include the leading dot, e.g. \".pdf\". Matching is case-insensitive.",
+      "description": "File extensions whose open viewers are automatically reloaded when the file changes on disk. Include the leading dot, e.g. \".pdf\". Matching is case-insensitive. Only use this for view-only or generated files: reloading reverts the open document from disk, so any unsaved edits to a watched file would be discarded.",
       "items": { "type": "string" },
       "default": [".pdf"]
     }

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -12,9 +12,16 @@
     "autoReloadIntervalMs": {
       "type": "number",
       "title": "Auto-reload poll interval (ms)",
-      "description": "How often to check open PDFs for on-disk changes, in milliseconds.",
+      "description": "How often to check open files for on-disk changes, in milliseconds.",
       "minimum": 250,
       "default": 1500
+    },
+    "watchedFileExtensions": {
+      "type": "array",
+      "title": "Watched file extensions",
+      "description": "File extensions whose open viewers are automatically reloaded when the file changes on disk. Include the leading dot, e.g. \".pdf\". Matching is case-insensitive.",
+      "items": { "type": "string" },
+      "default": [".pdf"]
     }
   },
   "additionalProperties": false,

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -5,8 +5,8 @@
   "properties": {
     "autoReloadEnabled": {
       "type": "boolean",
-      "title": "Auto-reload open PDFs on disk change",
-      "description": "When enabled, any open PDF viewer is automatically reloaded whenever its file changes on disk, regardless of what triggered the change (this command, an MCP/coding agent, a terminal, etc.).",
+      "title": "Auto-reload open files on disk change",
+      "description": "When enabled, any open file viewer (of a watched extension) is automatically reloaded whenever its file changes on disk, regardless of what triggered the change (this command, an MCP/coding agent, a terminal, etc.).",
       "default": true
     },
     "autoReloadIntervalMs": {

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -23,11 +23,6 @@
       "command": "run-and-reload:run-all-cells-and-reload",
       "keys": ["Accel Shift D"],
       "selector": ".jp-Notebook"
-    },
-    {
-      "command": "run-and-reload:restart-run-all-cells-and-reload",
-      "keys": ["Accel Shift Alt D"],
-      "selector": ".jp-Notebook"
     }
   ],
   "jupyter.lab.menus": {
@@ -41,16 +36,6 @@
             "args": { "ignoreIcon": true }
           }
         ]
-      },
-      {
-        "id": "jp-mainmenu-run",
-        "items": [
-          {
-            "command": "run-and-reload:restart-run-all-cells-and-reload",
-            "rank": 320,
-            "args": { "ignoreIcon": true }
-          }
-        ]
       }
     ]
   },
@@ -60,11 +45,6 @@
         "name": "Run all cells and reload",
         "command": "run-and-reload:run-all-cells-and-reload",
         "rank": 30
-      },
-      {
-        "name": "Restart kernel run all cells and reload",
-        "command": "run-and-reload:restart-run-all-cells-and-reload",
-        "rank": 35
       }
     ]
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,23 +31,27 @@ const PALETTE_CATEGORY = 'Run and reload extension';
 const DEFAULT_AUTO_RELOAD_ENABLED = true;
 const DEFAULT_AUTO_RELOAD_INTERVAL_MS = 1500;
 const MIN_AUTO_RELOAD_INTERVAL_MS = 250;
+const DEFAULT_WATCHED_EXTENSIONS = ['.pdf'];
 
 /**
- * Watches every open PDF viewer and reverts it whenever its file changes on
- * disk, no matter what caused the change (this extension's own command, an
- * MCP / coding agent running the notebook headlessly, a terminal, cron, ...).
+ * Watches every open viewer whose file has a watched extension (PDFs by
+ * default; configurable via the `watchedFileExtensions` setting) and reverts it
+ * whenever its file changes on disk, no matter what caused the change (this
+ * extension's own command, an MCP / coding agent running the notebook
+ * headlessly, a terminal, cron, ...).
  *
- * The extension command reaches into the browser to reload PDFs, but a headless
- * MCP run of the notebook has no browser handle and cannot do that. Detecting
- * the change on disk instead keeps the reload decoupled from whatever triggered
- * the regeneration, so both paths (and any other) work with no coupling.
+ * The extension command reaches into the browser to reload files, but a
+ * headless MCP run of the notebook has no browser handle and cannot do that.
+ * Detecting the change on disk instead keeps the reload decoupled from whatever
+ * triggered the regeneration, so both paths (and any other) work with no
+ * coupling.
  *
- * Detection is a periodic poll of each open PDF's `last_modified` via the
- * contents API rather than the context's `fileChanged` signal: a PDF that is
+ * Detection is a periodic poll of each open file's `last_modified` via the
+ * contents API rather than the context's `fileChanged` signal: a file that is
  * only being viewed (not edited) does not otherwise poll itself, so the signal
  * would not fire on an out-of-band regeneration.
  *
- * After reverting, the tab is activated. A hidden PDF tab does not re-render on
+ * After reverting, the tab is activated. A hidden tab does not re-render on
  * revert while it is not the visible tab, so activating it both surfaces the
  * updated document and forces the render. Widgets (not just contexts) are
  * tracked so each open tab has a handle to activate.
@@ -59,15 +63,33 @@ class PdfAutoReloader {
   }
 
   /** Apply settings; (re)starts or stops the poll loop as needed. */
-  configure(enabled: boolean, intervalMs: number): void {
+  configure(enabled: boolean, intervalMs: number, extensions: string[]): void {
     this._enabled = enabled;
     this._intervalMs = Math.max(MIN_AUTO_RELOAD_INTERVAL_MS, intervalMs);
+    this._extensions = PdfAutoReloader.normalizeExtensions(extensions);
     this._stopTimer();
     if (this._enabled) {
       this._timer = window.setInterval(() => {
         void this._tick();
       }, this._intervalMs);
     }
+  }
+
+  /** Lower-case each extension and ensure a leading dot; drop blanks. */
+  private static normalizeExtensions(extensions: string[]): string[] {
+    const normalized: string[] = [];
+    for (const raw of extensions) {
+      const ext = raw.trim().toLowerCase();
+      if (ext) {
+        normalized.push(ext.startsWith('.') ? ext : `.${ext}`);
+      }
+    }
+    return normalized;
+  }
+
+  private _isWatched(path: string): boolean {
+    const lower = path.toLowerCase();
+    return this._extensions.some(ext => lower.endsWith(ext));
   }
 
   private _stopTimer(): void {
@@ -77,14 +99,14 @@ class PdfAutoReloader {
     }
   }
 
-  /** One poll cycle: discover open PDF tabs, then reload any that changed. */
+  /** One poll cycle: discover open watched tabs, then reload any that changed. */
   private async _tick(): Promise<void> {
-    // Discover currently open PDF tabs (including hidden ones) and record a
+    // Discover currently open watched tabs (including hidden ones) and record a
     // baseline mtime for any we have not seen before (no reload on first sight).
     const openWidgets = new Set<Widget>();
     for (const widget of toArray(this._shell.widgets())) {
       const context = this._manager.contextForWidget(widget);
-      if (!context || !context.path.endsWith('.pdf')) {
+      if (!context || !this._isWatched(context.path)) {
         continue;
       }
       openWidgets.add(widget);
@@ -104,7 +126,7 @@ class PdfAutoReloader {
       }
     }
 
-    // Check each open PDF for an on-disk change and reload it if needed.
+    // Check each open watched file for an on-disk change and reload if needed.
     await Promise.all(
       Array.from(openWidgets).map(widget => this._maybeReload(widget))
     );
@@ -135,7 +157,7 @@ class PdfAutoReloader {
       state.reverting = true;
       try {
         await state.context.revert();
-        // Activate the tab so a hidden PDF actually re-renders (and the view
+        // Activate the tab so a hidden file actually re-renders (and the view
         // switches to it). Activating the already-visible tab is a no-op.
         this._shell.activateById(widget.id);
       } catch {
@@ -150,6 +172,7 @@ class PdfAutoReloader {
   private _manager: IDocumentManager;
   private _enabled = false;
   private _intervalMs = DEFAULT_AUTO_RELOAD_INTERVAL_MS;
+  private _extensions = DEFAULT_WATCHED_EXTENSIONS;
   private _timer: number | null = null;
   private _known = new Map<
     Widget,
@@ -165,10 +188,7 @@ class PdfAutoReloader {
  * Initialization data for the jupyterlab_run_and_reload extension.
  *
  * TODOs:
- * - Add setting: file extensions to reload
  * - Add setting: only reload visible widgets or not
- * - Add toolbar button in notebook panel with run and reload
- * - Also add "Restart kernel, run all cells and reload PDFs"
  */
 const plugin: JupyterFrontEndPlugin<void> = {
   id: 'jupyterlab_run_and_reload:plugin',
@@ -191,7 +211,8 @@ const plugin: JupyterFrontEndPlugin<void> = {
     const autoReloader = new PdfAutoReloader(shell, manager);
     autoReloader.configure(
       DEFAULT_AUTO_RELOAD_ENABLED,
-      DEFAULT_AUTO_RELOAD_INTERVAL_MS
+      DEFAULT_AUTO_RELOAD_INTERVAL_MS,
+      DEFAULT_WATCHED_EXTENSIONS
     );
 
     if (settingRegistry) {
@@ -199,9 +220,12 @@ const plugin: JupyterFrontEndPlugin<void> = {
         const enabled = settings.get('autoReloadEnabled').composite as boolean;
         const intervalMs = settings.get('autoReloadIntervalMs')
           .composite as number;
+        const extensions = settings.get('watchedFileExtensions')
+          .composite as string[];
         autoReloader.configure(
           enabled ?? DEFAULT_AUTO_RELOAD_ENABLED,
-          intervalMs ?? DEFAULT_AUTO_RELOAD_INTERVAL_MS
+          intervalMs ?? DEFAULT_AUTO_RELOAD_INTERVAL_MS,
+          extensions ?? DEFAULT_WATCHED_EXTENSIONS
         );
       };
       settingRegistry

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,7 @@ const MIN_AUTO_RELOAD_INTERVAL_MS = 250;
 const DEFAULT_WATCHED_EXTENSIONS = ['.pdf'];
 
 /**
- * Watches every open viewer whose file has a watched extension (PDFs by
+ * Watches every open viewer whose file has a watched extension (`.pdf` by
  * default; configurable via the `watchedFileExtensions` setting) and reverts it
  * whenever its file changes on disk, no matter what caused the change (this
  * extension's own command, an MCP / coding agent running the notebook
@@ -56,7 +56,7 @@ const DEFAULT_WATCHED_EXTENSIONS = ['.pdf'];
  * updated document and forces the render. Widgets (not just contexts) are
  * tracked so each open tab has a handle to activate.
  */
-class PdfAutoReloader {
+class FileAutoReloader {
   constructor(shell: JupyterFrontEnd.IShell, manager: IDocumentManager) {
     this._shell = shell;
     this._manager = manager;
@@ -66,7 +66,7 @@ class PdfAutoReloader {
   configure(enabled: boolean, intervalMs: number, extensions: string[]): void {
     this._enabled = enabled;
     this._intervalMs = Math.max(MIN_AUTO_RELOAD_INTERVAL_MS, intervalMs);
-    this._extensions = PdfAutoReloader.normalizeExtensions(extensions);
+    this._extensions = FileAutoReloader.normalizeExtensions(extensions);
     this._stopTimer();
     if (this._enabled) {
       this._timer = window.setInterval(() => {
@@ -205,10 +205,10 @@ const plugin: JupyterFrontEndPlugin<void> = {
 
     const { shell, commands } = app;
 
-    // Auto-reload open PDFs when their file changes on disk. This is what makes
+    // Auto-reload open files when they change on disk. This is what makes
     // headless notebook runs (e.g. via the Jupyter MCP / coding agents) refresh
-    // open PDFs too, without any coupling to how the run was triggered.
-    const autoReloader = new PdfAutoReloader(shell, manager);
+    // open files too, without any coupling to how the run was triggered.
+    const autoReloader = new FileAutoReloader(shell, manager);
     autoReloader.configure(
       DEFAULT_AUTO_RELOAD_ENABLED,
       DEFAULT_AUTO_RELOAD_INTERVAL_MS,
@@ -251,9 +251,9 @@ const plugin: JupyterFrontEndPlugin<void> = {
       svgstr: playInFileIconStr
     });
 
-    // Just run all cells: reloading of open PDFs is now handled automatically
-    // by the PdfAutoReloader watcher when the files change on disk, so this
-    // command no longer needs to find and revert PDF widgets itself.
+    // Just run all cells: reloading of open files is now handled automatically
+    // by the FileAutoReloader watcher when the files change on disk, so this
+    // command no longer needs to find and revert file widgets itself.
     //
     // Use runCells rather than runAll: runAll moves the active cell to the last
     // cell and scrolls there, which is jarring. runCells runs every cell while
@@ -271,9 +271,9 @@ const plugin: JupyterFrontEndPlugin<void> = {
     }
 
     commands.addCommand(CommandIDs.runAndReloadAll, {
-      label: 'Run All Cells and Reload PDFs',
+      label: 'Run All Cells and Reload Files',
       caption:
-        'Run all the cells of the notebook. Open PDFs are reloaded automatically when they change on disk.',
+        'Run all the cells of the notebook. Open files are reloaded automatically when they change on disk.',
       icon: args => (args['ignoreIcon'] ? undefined : icon),
       isEnabled: () => shell.currentWidget instanceof NotebookPanel,
       execute: runAllCells

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,8 @@ import { NotebookActions, NotebookPanel } from '@jupyterlab/notebook';
 
 import { Widget } from '@lumino/widgets';
 
+import { DocumentRegistry } from '@jupyterlab/docregistry';
+
 import { LabIcon } from '@jupyterlab/ui-components';
 
 import playInFileIconStr from '../style/play-in-file.svg';
@@ -29,6 +31,126 @@ namespace CommandIDs {
 
 // TODO: Change category to run items
 const PALETTE_CATEGORY = 'Run and reload extension';
+
+// Default settings, kept in sync with schema/plugin.json.
+const DEFAULT_AUTO_RELOAD_ENABLED = true;
+const DEFAULT_AUTO_RELOAD_INTERVAL_MS = 1500;
+const MIN_AUTO_RELOAD_INTERVAL_MS = 250;
+
+/**
+ * Watches every open PDF viewer and reverts it whenever its file changes on
+ * disk, no matter what caused the change (this extension's own command, an
+ * MCP / coding agent running the notebook headlessly, a terminal, cron, ...).
+ *
+ * The extension command reaches into the browser to reload PDFs, but a headless
+ * MCP run of the notebook has no browser handle and cannot do that. Detecting
+ * the change on disk instead keeps the reload decoupled from whatever triggered
+ * the regeneration, so both paths (and any other) work with no coupling.
+ *
+ * Detection is a periodic poll of each open PDF's `last_modified` via the
+ * contents API rather than the context's `fileChanged` signal: a PDF that is
+ * only being viewed (not edited) does not otherwise poll itself, so the signal
+ * would not fire on an out-of-band regeneration.
+ */
+class PdfAutoReloader {
+  constructor(shell: JupyterFrontEnd.IShell, manager: IDocumentManager) {
+    this._shell = shell;
+    this._manager = manager;
+  }
+
+  /** Apply settings; (re)starts or stops the poll loop as needed. */
+  configure(enabled: boolean, intervalMs: number): void {
+    this._enabled = enabled;
+    this._intervalMs = Math.max(MIN_AUTO_RELOAD_INTERVAL_MS, intervalMs);
+    this._stopTimer();
+    if (this._enabled) {
+      this._timer = window.setInterval(() => {
+        void this._tick();
+      }, this._intervalMs);
+    }
+  }
+
+  private _stopTimer(): void {
+    if (this._timer !== null) {
+      window.clearInterval(this._timer);
+      this._timer = null;
+    }
+  }
+
+  /** One poll cycle: discover open PDFs, then reload any that changed. */
+  private async _tick(): Promise<void> {
+    // Discover currently open PDF contexts and record a baseline mtime for any
+    // we have not seen before (without reloading on first sight).
+    const openContexts = new Set<DocumentRegistry.Context>();
+    for (const widget of toArray(this._shell.widgets())) {
+      const context = this._manager.contextForWidget(widget);
+      if (!context || !context.path.endsWith('.pdf')) {
+        continue;
+      }
+      openContexts.add(context);
+      if (!this._known.has(context)) {
+        this._known.set(context, {
+          lastModified: context.contentsModel?.last_modified ?? null,
+          reverting: false
+        });
+      }
+    }
+
+    // Drop contexts whose widget is no longer open.
+    for (const context of this._known.keys()) {
+      if (!openContexts.has(context)) {
+        this._known.delete(context);
+      }
+    }
+
+    // Check each open PDF for an on-disk change and revert if needed.
+    await Promise.all(
+      Array.from(openContexts).map(context => this._maybeReload(context))
+    );
+  }
+
+  private async _maybeReload(context: DocumentRegistry.Context): Promise<void> {
+    const state = this._known.get(context);
+    if (!state || state.reverting) {
+      return;
+    }
+    let lastModified: string;
+    try {
+      const model = await this._manager.services.contents.get(context.path, {
+        content: false
+      });
+      lastModified = model.last_modified;
+    } catch {
+      // File may have been deleted or is temporarily unreadable; skip this tick.
+      return;
+    }
+    if (state.lastModified === null) {
+      state.lastModified = lastModified;
+      return;
+    }
+    if (lastModified !== state.lastModified) {
+      state.lastModified = lastModified;
+      state.reverting = true;
+      try {
+        await context.revert();
+      } catch {
+        // Ignore; a later tick will retry if the file changes again.
+      } finally {
+        state.reverting = false;
+      }
+    }
+  }
+
+  private _shell: JupyterFrontEnd.IShell;
+  private _manager: IDocumentManager;
+  private _enabled = false;
+  private _intervalMs = DEFAULT_AUTO_RELOAD_INTERVAL_MS;
+  private _timer: number | null = null;
+  private _known = new Map<
+    DocumentRegistry.Context,
+    { lastModified: string | null; reverting: boolean }
+  >();
+}
 
 /**
  * Initialization data for the jupyterlab_run_and_reload extension.
@@ -52,7 +174,27 @@ const plugin: JupyterFrontEndPlugin<void> = {
   ) => {
     console.log('JupyterLab extension jupyterlab_run_and_reload is activated!');
 
+    const { shell, commands } = app;
+
+    // Auto-reload open PDFs when their file changes on disk. This is what makes
+    // headless notebook runs (e.g. via the Jupyter MCP / coding agents) refresh
+    // open PDFs too, without any coupling to how the run was triggered.
+    const autoReloader = new PdfAutoReloader(shell, manager);
+    autoReloader.configure(
+      DEFAULT_AUTO_RELOAD_ENABLED,
+      DEFAULT_AUTO_RELOAD_INTERVAL_MS
+    );
+
     if (settingRegistry) {
+      const applySettings = (settings: ISettingRegistry.ISettings) => {
+        const enabled = settings.get('autoReloadEnabled').composite as boolean;
+        const intervalMs = settings.get('autoReloadIntervalMs')
+          .composite as number;
+        autoReloader.configure(
+          enabled ?? DEFAULT_AUTO_RELOAD_ENABLED,
+          intervalMs ?? DEFAULT_AUTO_RELOAD_INTERVAL_MS
+        );
+      };
       settingRegistry
         .load(plugin.id)
         .then(settings => {
@@ -60,6 +202,8 @@ const plugin: JupyterFrontEndPlugin<void> = {
             'jupyterlab_run_and_reload settings loaded:',
             settings.composite
           );
+          applySettings(settings);
+          settings.changed.connect(applySettings);
         })
         .catch(reason => {
           console.error(
@@ -68,8 +212,6 @@ const plugin: JupyterFrontEndPlugin<void> = {
           );
         });
     }
-
-    const { shell, commands } = app;
 
     const icon = new LabIcon({
       name: 'run-and-reload:play-in-file-icon',

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,14 +19,9 @@ import { DocumentRegistry } from '@jupyterlab/docregistry';
 import { LabIcon } from '@jupyterlab/ui-components';
 
 import playInFileIconStr from '../style/play-in-file.svg';
-import fastforwardInFileIconStr from '../style/fastforward-in-file.svg';
 
 namespace CommandIDs {
   export const runAndReloadAll = 'run-and-reload:run-all-cells-and-reload';
-  export const restartRunAndReloadAll =
-    'run-and-reload:restart-run-all-cells-and-reload';
-  // TODO: Import this from notebook extension
-  export const restart = 'notebook:restart-kernel';
 }
 
 // TODO: Change category to run items
@@ -232,98 +227,33 @@ const plugin: JupyterFrontEndPlugin<void> = {
       svgstr: playInFileIconStr
     });
 
-    const icon2 = new LabIcon({
-      name: 'run-and-reload:fastforward-in-file-icon',
-      svgstr: fastforwardInFileIconStr
-    });
-
-    function commandExecutionFunction(withRestart: boolean) {
-      async function executeCommand() {
-        // Get currently selected widget
-        const currentWidget = shell.currentWidget;
-
-        // If current widget is a notebook then we can run all cells
-        // If not, then this command does not make sense and should not be callable actually
-        if (!(currentWidget instanceof NotebookPanel)) {
-          return;
-        }
-
-        function widgetShouldReload(widget: Widget) {
-          const context = manager.contextForWidget(widget);
-          return context?.path.endsWith('.pdf');
-        }
-
-        // Get all attached widgets in the shell
-        const currentWidgets = toArray(shell.widgets());
-
-        // Obtain the list of widgets that might need to be reloaded after the notebook is finished
-        const widgetsToReload = currentWidgets.filter(widgetShouldReload);
-        const contextsToReload = widgetsToReload.map(widget =>
-          manager.contextForWidget(widget)
-        );
-
-        // Connect the openOrReveal function to the fileChanged signal of the relevant widgets
-        contextsToReload.forEach(context => {
-          context?.fileChanged.connect((context, model) => {
-            manager.openOrReveal(context.path);
-          });
-        });
-
-        // If current widget is a notebook then we can run all cells
-        if (currentWidget instanceof NotebookPanel) {
-          let restarted: boolean;
-          if (withRestart) {
-            restarted = await commands.execute(CommandIDs.restart, {
-              activate: false
-            });
-          } else {
-            restarted = true;
-          }
-          // TODO: Add check on result + notification if notebook run was not successfull
-          if (restarted) {
-            await NotebookActions.runAll(
-              currentWidget.content,
-              currentWidget.sessionContext
-            );
-          }
-
-          // Loop over all widgets in the shell and revert the relevant ones
-          for (const context of contextsToReload) {
-            context?.revert();
-          }
-        }
+    // Just run all cells: reloading of open PDFs is now handled automatically
+    // by the PdfAutoReloader watcher when the files change on disk, so this
+    // command no longer needs to find and revert PDF widgets itself.
+    async function runAllCells(): Promise<void> {
+      const currentWidget = shell.currentWidget;
+      if (!(currentWidget instanceof NotebookPanel)) {
+        return;
       }
-      return executeCommand;
+      await NotebookActions.runAll(
+        currentWidget.content,
+        currentWidget.sessionContext
+      );
     }
 
     commands.addCommand(CommandIDs.runAndReloadAll, {
       label: 'Run All Cells and Reload PDFs',
       caption:
-        'Run all the cells of the notebook and then reload static content that has changed (e.g. PDF).',
+        'Run all the cells of the notebook. Open PDFs are reloaded automatically when they change on disk.',
       icon: args => (args['ignoreIcon'] ? undefined : icon),
       isEnabled: () => shell.currentWidget instanceof NotebookPanel,
-      execute: commandExecutionFunction(false)
-    });
-
-    commands.addCommand(CommandIDs.restartRunAndReloadAll, {
-      label: 'Restart Kernel, Run All Cells and Reload PDFs',
-      caption:
-        'Restart the kernel, run all the cells of the notebook and then reload static content that has changed (e.g. PDF).',
-      icon: args => (args['ignoreIcon'] ? undefined : icon2),
-      isEnabled: () => shell.currentWidget instanceof NotebookPanel,
-      execute: commandExecutionFunction(true)
+      execute: runAllCells
     });
 
     // Add the command to the palette
     if (palette) {
       palette.addItem({
         command: CommandIDs.runAndReloadAll,
-        args: { ignoreIcon: true },
-        category: PALETTE_CATEGORY
-      });
-
-      palette.addItem({
-        command: CommandIDs.restartRunAndReloadAll,
         args: { ignoreIcon: true },
         category: PALETTE_CATEGORY
       });

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,11 @@ const MIN_AUTO_RELOAD_INTERVAL_MS = 250;
  * contents API rather than the context's `fileChanged` signal: a PDF that is
  * only being viewed (not edited) does not otherwise poll itself, so the signal
  * would not fire on an out-of-band regeneration.
+ *
+ * After reverting, the tab is activated. A hidden PDF tab does not re-render on
+ * revert while it is not the visible tab, so activating it both surfaces the
+ * updated document and forces the render. Widgets (not just contexts) are
+ * tracked so each open tab has a handle to activate.
  */
 class PdfAutoReloader {
   constructor(shell: JupyterFrontEnd.IShell, manager: IDocumentManager) {
@@ -77,48 +82,50 @@ class PdfAutoReloader {
     }
   }
 
-  /** One poll cycle: discover open PDFs, then reload any that changed. */
+  /** One poll cycle: discover open PDF tabs, then reload any that changed. */
   private async _tick(): Promise<void> {
-    // Discover currently open PDF contexts and record a baseline mtime for any
-    // we have not seen before (without reloading on first sight).
-    const openContexts = new Set<DocumentRegistry.Context>();
+    // Discover currently open PDF tabs (including hidden ones) and record a
+    // baseline mtime for any we have not seen before (no reload on first sight).
+    const openWidgets = new Set<Widget>();
     for (const widget of toArray(this._shell.widgets())) {
       const context = this._manager.contextForWidget(widget);
       if (!context || !context.path.endsWith('.pdf')) {
         continue;
       }
-      openContexts.add(context);
-      if (!this._known.has(context)) {
-        this._known.set(context, {
+      openWidgets.add(widget);
+      if (!this._known.has(widget)) {
+        this._known.set(widget, {
+          context,
           lastModified: context.contentsModel?.last_modified ?? null,
           reverting: false
         });
       }
     }
 
-    // Drop contexts whose widget is no longer open.
-    for (const context of this._known.keys()) {
-      if (!openContexts.has(context)) {
-        this._known.delete(context);
+    // Drop tabs that are no longer open.
+    for (const widget of this._known.keys()) {
+      if (!openWidgets.has(widget)) {
+        this._known.delete(widget);
       }
     }
 
-    // Check each open PDF for an on-disk change and revert if needed.
+    // Check each open PDF for an on-disk change and reload it if needed.
     await Promise.all(
-      Array.from(openContexts).map(context => this._maybeReload(context))
+      Array.from(openWidgets).map(widget => this._maybeReload(widget))
     );
   }
 
-  private async _maybeReload(context: DocumentRegistry.Context): Promise<void> {
-    const state = this._known.get(context);
+  private async _maybeReload(widget: Widget): Promise<void> {
+    const state = this._known.get(widget);
     if (!state || state.reverting) {
       return;
     }
     let lastModified: string;
     try {
-      const model = await this._manager.services.contents.get(context.path, {
-        content: false
-      });
+      const model = await this._manager.services.contents.get(
+        state.context.path,
+        { content: false }
+      );
       lastModified = model.last_modified;
     } catch {
       // File may have been deleted or is temporarily unreadable; skip this tick.
@@ -132,7 +139,10 @@ class PdfAutoReloader {
       state.lastModified = lastModified;
       state.reverting = true;
       try {
-        await context.revert();
+        await state.context.revert();
+        // Activate the tab so a hidden PDF actually re-renders (and the view
+        // switches to it). Activating the already-visible tab is a no-op.
+        this._shell.activateById(widget.id);
       } catch {
         // Ignore; a later tick will retry if the file changes again.
       } finally {
@@ -147,8 +157,12 @@ class PdfAutoReloader {
   private _intervalMs = DEFAULT_AUTO_RELOAD_INTERVAL_MS;
   private _timer: number | null = null;
   private _known = new Map<
-    DocumentRegistry.Context,
-    { lastModified: string | null; reverting: boolean }
+    Widget,
+    {
+      context: DocumentRegistry.Context;
+      lastModified: string | null;
+      reverting: boolean;
+    }
   >();
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -230,13 +230,18 @@ const plugin: JupyterFrontEndPlugin<void> = {
     // Just run all cells: reloading of open PDFs is now handled automatically
     // by the PdfAutoReloader watcher when the files change on disk, so this
     // command no longer needs to find and revert PDF widgets itself.
+    //
+    // Use runCells rather than runAll: runAll moves the active cell to the last
+    // cell and scrolls there, which is jarring. runCells runs every cell while
+    // preserving the current selection and scroll position (cf. PR #15).
     async function runAllCells(): Promise<void> {
       const currentWidget = shell.currentWidget;
       if (!(currentWidget instanceof NotebookPanel)) {
         return;
       }
-      await NotebookActions.runAll(
+      await NotebookActions.runCells(
         currentWidget.content,
+        currentWidget.content.widgets,
         currentWidget.sessionContext
       );
     }

--- a/style/fastforward-in-file.svg
+++ b/style/fastforward-in-file.svg
@@ -1,5 +1,0 @@
-<svg fill="var(--jp-icon-contrast-color0)" xmlns="http://www.w3.org/2000/svg"  viewBox="0 0 30 30" width="210px" height="210px">
-<path d="M24.707,8.793l-6.5-6.5C18.019,2.105,17.765,2,17.5,2H7C5.895,2,5,2.895,5,4v22c0,1.105,0.895,2,2,2h16c1.105,0,2-0.895,2-2V9.5C25,9.235,24.895,8.981,24.707,8.793z M18,10c-0.552,0-1-0.448-1-1V3.904L23.096,10H18z"/>
-<polygon points="8,15 8,23 15,19" style="fill:var(--jp-toolbar-background);stroke:var(--jp-toolbar-background);stroke-width:1;stroke-linejoin:round" />
-<polygon points="15,15 15,23 22,19" style="fill:var(--jp-toolbar-background);stroke:var(--jp-toolbar-background);stroke-width:1;stroke-linejoin:round" />
-</svg>


### PR DESCRIPTION
## Summary

Reworks the extension around an **always-on, disk-change-driven reload**: a background watcher (`PdfAutoReloader`) automatically reloads any open viewer whose file changes on disk — regardless of what triggered the change (this extension's command, a headless Jupyter MCP / coding-agent run, a terminal, cron, …). With that in place, the commands are simplified and the reload no longer depends on running a command.

Watched file types are configurable (default `.pdf`). The extension version becomes `4.1.0`.

## Motivation

The old "Run all cells and reload PDFs" command reached into the browser to reload open PDF widgets. That works interactively, but a **headless notebook run via the Jupyter MCP** (used by Codex/Claude coding agents) executes cells straight against the kernel — no browser handle, so it can't invoke a frontend command, and regenerated PDFs never refreshed in open tabs.

Rather than couple the MCP to the browser (fragile — and there isn't even a single "run all" MCP tool; agents loop `execute_cell`), the reload is **decoupled** and made disk-change driven. Any process that regenerates a watched file now refreshes the open viewer, with no coupling to how it was triggered.

## What changed

**Auto-reload watcher (`src/index.ts`)**
- New `PdfAutoReloader`, wired into `activate`. It polls each open watched file's `last_modified` via the contents API and calls `context.revert()` when the file changes on disk. Handles first-sight baselining (no spurious reload), closed-tab cleanup, an in-flight `reverting` guard, and swallows transient errors. Reads settings and reconfigures live on `settings.changed`.
- **Polling** (rather than the context `fileChanged` signal) is deliberate: a file that is only being viewed does not otherwise poll itself, so the signal would not fire on an out-of-band regeneration.
- **Hidden tabs** are watched too. A hidden tab does not re-render on `revert` while it isn't the visible tab, so after reverting the tab is **activated** — surfacing the updated document and forcing the render. Widgets (not just contexts) are tracked so each open tab has a handle to activate.

**Command cleanup**
- "Run all cells and reload PDFs" now **just runs all cells** (reload is handled by the watcher); its PDF-finding/`revert` logic is removed.
- Uses `NotebookActions.runCells` instead of `runAll`, so running **no longer jumps/scrolls to the last cell** — selection and scroll position are preserved. (Applies the fix from #15, which is superseded by this PR.)
- The "Restart Kernel, Run All Cells and Reload PDFs" command is **removed** (button, menu item, palette item, shortcut), along with its now-unused fastforward icon.

**Settings (`schema/plugin.json`)**
- `autoReloadEnabled` — default `true`.
- `autoReloadIntervalMs` — min `250`, default `1500`.
- `watchedFileExtensions` — default `[".pdf"]`; case-insensitive, leading dot enforced. Add e.g. `.png`/`.svg` to auto-reload other viewers. Documented caveat: reloading **reverts from disk**, so only view-only/generated file types should be watched (unsaved edits to a watched file would be discarded).

**Packaging**
- `package.json`: added `@jupyterlab/docregistry` (for the `DocumentRegistry.Context` type); version → `4.1.0`.
- Added `recipe/meta.yaml` (conda-build recipe) so the extension can be built as a conda package for the TWD `forked_jlab_extensions` channel. Reads name/version from `package.json` (can't drift) and declares `nodejs` in host so a clean build runs the labextension JS build.

**Docs**
- README rewritten for the single command + always-on reload behavior, and documents all three settings and the revert caveat.

## Testing

- `tsc --noEmit`, `eslint`, `prettier` all pass; `schema/plugin.json` is valid JSON.
- Built and deployed to the staged-release env on the jupyter-dev server throughout development (`jupyter labextension list` → `v4.1.0 enabled OK`); verified auto-reload (incl. hidden-tab activation), no-jump run, and the configurable-extensions setting live.

## Notes
- Supersedes #15 (closed): its `runCells` fix and conda recipe are both incorporated here.
